### PR TITLE
fix deprecated byte [] access

### DIFF
--- a/calN50.js
+++ b/calN50.js
@@ -93,8 +93,8 @@ function main(args) {
 	var a = [];
 	while (file.readline(buf) >= 0) {
 		if (buf.length == 0) continue;
-		if (buf[0] == 62) { // fasta header
-			var m, s = buf.toString();
+		var m, s = buf.toString();
+		if (s[0] == ">") { // fasta header
 			if ((m = /^>(\S+)/.exec(s)) != null) {
 				if (name) a.push([name, len]);
 				is_fa = true, name = m[1], len = 0;


### PR DESCRIPTION
In k8-1.0, byte access was removed
> Bytes[] - not possible to implement. Use Bytes.buffer as a partial remedy

but this was used in calN50.js to check if a fasta line was a header or sequence. This silently failed when running and would error out as "No sequence found".

This is probably an inefficient fix as it converts every line to strings and then checks for header lines, but I couldn't find a direct way to access the byte buffer without first converting to a view which might have a similar performance loss anyway.
